### PR TITLE
Added more Bing Maps options like "Aerial with Labels"

### DIFF
--- a/src/main/java/com/sothawo/mapjfx/MapType.java
+++ b/src/main/java/com/sothawo/mapjfx/MapType.java
@@ -28,8 +28,16 @@ public enum MapType {
     STAMEN_WC,
     /** BingMaps Road. */
     BINGMAPS_ROAD,
+    /** BingMaps Road as a grayscale version */
+    BINGMAPS_CANVAS_GRAY,
+    /** BingMaps Road as a dark version*/
+    BINGMAPS_CANVAS_DARK,
+    /** BingMaps Road as a lighter version*/
+    BINGMAPS_CANVAS_LIGHT,
     /** BingMaps Aerial. */
     BINGMAPS_AERIAL,
+    /** BingMaps Aerial with labels. */
+    BINGMAPS_AERIAL_WITH_LABELS,
     /** custom WMS server. */
     WMS,
     /** custom Map server with XYZ support. */

--- a/src/main/java/com/sothawo/mapjfx/MapView.java
+++ b/src/main/java/com/sothawo/mapjfx/MapView.java
@@ -374,6 +374,10 @@ public final class MapView extends Region implements AutoCloseable {
         switch (requireNonNull(mapTypeToCheck)) {
             case BINGMAPS_ROAD:
             case BINGMAPS_AERIAL:
+            case BINGMAPS_AERIAL_WITH_LABELS:
+            case BINGMAPS_CANVAS_DARK:
+            case BINGMAPS_CANVAS_GRAY:
+            case BINGMAPS_CANVAS_LIGHT:
                 return bingMapsApiKey.isPresent();
             default:
                 return true;

--- a/src/main/java/com/sothawo/mapjfx/app/TestApp.java
+++ b/src/main/java/com/sothawo/mapjfx/app/TestApp.java
@@ -27,6 +27,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.MenuButton;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
@@ -418,21 +420,54 @@ public class TestApp extends Application {
         btn.setOnAction(evt -> mapView.setMapType(MapType.STAMEN_WC));
         hbox.getChildren().add(btn);
 
-        btn = new Button();
-        btn.setText("BR");
-        btn.setOnAction(evt -> {
+        LinkedList<MenuItem> bingOptions = new LinkedList<>();
+        MenuItem item = new MenuItem("Bing Roads");
+        item.setOnAction(evt -> {
             mapView.setBingMapsApiKey(bingApiKey.getText());
             mapView.setMapType(MapType.BINGMAPS_ROAD);
         });
-        hbox.getChildren().add(btn);
+        bingOptions.add(item);
 
-        btn = new Button();
-        btn.setText("BA");
-        btn.setOnAction(evt -> {
+        item = new MenuItem("Bing Aerial");
+        item.setOnAction(evt -> {
             mapView.setBingMapsApiKey(bingApiKey.getText());
             mapView.setMapType(MapType.BINGMAPS_AERIAL);
         });
-        hbox.getChildren().add(btn);
+        bingOptions.add(item);
+
+        item = new MenuItem("Bing Aerial with Labels");
+        item.setOnAction(evt -> {
+            mapView.setBingMapsApiKey(bingApiKey.getText());
+            mapView.setMapType(MapType.BINGMAPS_AERIAL_WITH_LABELS);
+        });
+        bingOptions.add(item);
+
+        item = new MenuItem("Bing Roads - dark");
+        item.setOnAction(evt -> {
+            mapView.setBingMapsApiKey(bingApiKey.getText());
+            mapView.setMapType(MapType.BINGMAPS_CANVAS_DARK);
+        });
+        bingOptions.add(item);
+
+        item = new MenuItem("Bing Roads - grayscale");
+        item.setOnAction(evt -> {
+            mapView.setBingMapsApiKey(bingApiKey.getText());
+            mapView.setMapType(MapType.BINGMAPS_CANVAS_GRAY);
+        });
+        bingOptions.add(item);
+
+        item = new MenuItem("Bing Roads - light");
+        item.setOnAction(evt -> {
+            mapView.setBingMapsApiKey(bingApiKey.getText());
+            mapView.setMapType(MapType.BINGMAPS_CANVAS_LIGHT);
+        });
+        bingOptions.add(item);
+
+
+
+        MenuButton menuButton = new MenuButton("Bing", null, bingOptions.toArray(new MenuItem[0]));
+        hbox.getChildren().add(menuButton);
+
 
         btn = new Button();
         btn.setText("WMS");

--- a/src/main/resources/mapview.js
+++ b/src/main/resources/mapview.js
@@ -288,6 +288,58 @@ JSMapView.prototype.setMapType = function (newType) {
                 this.layerFeatures
             ]
         }));
+    } else if (newType === 'BINGMAPS_AERIAL_WITH_LABELS') {
+        this.map.setLayerGroup(new ol.layer.Group({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.BingMaps({
+                        imagerySet: 'AerialWithLabelsOnDemand',
+                        key: this.bingMapsApiKey,
+                        projection: new ol.proj.Projection(this.projections.openlayers)
+                    })
+                }),
+                this.layerFeatures
+            ]
+        }));
+    } else if (newType === 'BINGMAPS_CANVAS_GRAY') {
+        this.map.setLayerGroup(new ol.layer.Group({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.BingMaps({
+                        imagerySet: 'CanvasGray',
+                        key: this.bingMapsApiKey,
+                        projection: new ol.proj.Projection(this.projections.openlayers)
+                    })
+                }),
+                this.layerFeatures
+            ]
+        }));
+    } else if (newType === 'BINGMAPS_CANVAS_DARK') {
+        this.map.setLayerGroup(new ol.layer.Group({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.BingMaps({
+                        imagerySet: 'CanvasDark',
+                        key: this.bingMapsApiKey,
+                        projection: new ol.proj.Projection(this.projections.openlayers)
+                    })
+                }),
+                this.layerFeatures
+            ]
+        }));
+    } else if (newType === 'BINGMAPS_CANVAS_LIGHT') {
+        this.map.setLayerGroup(new ol.layer.Group({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.BingMaps({
+                        imagerySet: 'CanvasLight',
+                        key: this.bingMapsApiKey,
+                        projection: new ol.proj.Projection(this.projections.openlayers)
+                    })
+                }),
+                this.layerFeatures
+            ]
+        }));
     } else if (newType === 'STAMEN_WC') {
         this.map.setLayerGroup(new ol.layer.Group({
             layers: [

--- a/src/main/resources/mapview.js
+++ b/src/main/resources/mapview.js
@@ -267,7 +267,7 @@ JSMapView.prototype.setMapType = function (newType) {
             layers: [
                 new ol.layer.Tile({
                     source: new ol.source.BingMaps({
-                        imagerySet: 'Road',
+                        imagerySet: 'RoadOnDemand',
                         key: this.bingMapsApiKey,
                         projection: new ol.proj.Projection(this.projections.openlayers)
                     })


### PR DESCRIPTION
Hey,

I added more Bing Maps options to mapjfx and the test application com.sothawo.mapjfx.app.TestApp:
Aerial with Labels and grayscale, dark and light Roads. 
The needed imagerySet parameter is sourced from the [Microsoft docs](https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata). 
My javascript knowledge is essentially non-existent, it is most likely possible to avoid my if/else nesting in mapview.js with a map. 

(Small addition, based on the [Microsoft docs](https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata) the imagerySet parameter "Road" used in mapview.js is deprecated and should be replaced by RoadOnDemand, should I create that as an issue or create another pull request?)